### PR TITLE
Disabling CAS plugin

### DIFF
--- a/SpringSecurityCasGrailsPlugin.groovy
+++ b/SpringSecurityCasGrailsPlugin.groovy
@@ -106,11 +106,12 @@ class SpringSecurityCasGrailsPlugin {
  
 			SpringSecurityUtils.loadSecondaryConfig 'DefaultCasSecurityConfig'
 			conf = SpringSecurityUtils.securityConfig
-			if (!conf.cas.active) {
-				return
-			}
 		}
 
+        if (!conf.cas.active) {
+            return
+        }
+        
 		println 'Configuring Spring Security CAS ...'
 
 		SpringSecurityUtils.registerProvider 'casAuthenticationProvider'


### PR DESCRIPTION
You cannot disable CAS plugin when not running war -file (Or actually can, but then the whole springsecurity is disabled).
