### PR TITLE
Fix the multiple 'CAS Single Sign Out Filter' in web.xml

### DIFF
--- a/SpringSecurityCasGrailsPlugin.groovy
+++ b/SpringSecurityCasGrailsPlugin.groovy
@@ -81,8 +81,7 @@ class SpringSecurityCasGrailsPlugin {
 
 		// add the filter-mapping right after the last filter
 		def mappingLocation = xml.'filter'
-		// TODO  this gets in there 2x
-		mappingLocation + {
+		mappingLocation[mappingLocation.size() - 1] + {
 			'filter-mapping'{
 				'filter-name'('CAS Single Sign Out Filter')
 				'url-pattern'('/*')


### PR DESCRIPTION
There was a TODO about multiple

```
    <filter-mapping>
        <filter-name>CAS Single Sign Out Filter</filter-name>
        <url-pattern>/*</url-pattern>
    </filter-mapping>
```

blocks in web.xml. This is a fix to only have it once
