### PR TITLE
always load secondary config in doWithSpring

### DIFF
--- a/SpringSecurityCasGrailsPlugin.groovy
+++ b/SpringSecurityCasGrailsPlugin.groovy
@@ -101,13 +101,10 @@ class SpringSecurityCasGrailsPlugin {
 			return
 		}
 
-		if (application.warDeployed) {
-			// need to load secondary here since web.xml was already built, so
-			// doWithWebDescriptor isn't called when deployed as war
-
-			SpringSecurityUtils.loadSecondaryConfig 'DefaultCasSecurityConfig'
-			conf = SpringSecurityUtils.securityConfig
-		}
+		// need to load secondary here since web.xml was already built, so
+		// doWithWebDescriptor isn't called when deployed as war
+		SpringSecurityUtils.loadSecondaryConfig 'DefaultCasSecurityConfig'
+		conf = SpringSecurityUtils.securityConfig
 
 		if (!conf.cas.active) {
 			return


### PR DESCRIPTION
Default cas config values are not available unless the default cas config
file is loaded in doWithSpring. Checking cas.active will return false
unless it is explicitly set to true in the application's Config.groovy file
causing doWithSpring to return early.