### PR TITLE
disable session fixation prevention if single sign out is enabled

### DIFF
--- a/SpringSecurityCasGrailsPlugin.groovy
+++ b/SpringSecurityCasGrailsPlugin.groovy
@@ -64,7 +64,9 @@ class SpringSecurityCasGrailsPlugin {
 			return
 		}
 
-		if (!conf.cas.useSingleSignout) {
+		if (conf.cas.useSingleSignout) {
+			conf.useSessionFixationPrevention = false
+		} else {
 			return
 		}
 


### PR DESCRIPTION
After successfuly CAS authentiction, the CAS SingleSignOutHandler maps
the service ticket to the current session ID. When session fixation
prevention is enabled, the session is then immediately destroyed and
the mapping deleted. Later, when the application receives a logout
request from the CAS server (note that this applies when the user logs
out of CAS but not directly from the current application), the service
ticket is no longer mapped to the current session ID and the user cannot
be logged out. In essence, this breaks the single sign out functionality.